### PR TITLE
error handler for requests

### DIFF
--- a/src/Type/Usage.php
+++ b/src/Type/Usage.php
@@ -49,7 +49,7 @@ class Usage implements ArrayConverterInterface
             $array['prompt_tokens'],
             $array['completion_tokens'],
             $array['total_tokens'],
-            $array['system_tokens']
+            $array['system_tokens'] ?? 0,
         );
     }
 }


### PR DESCRIPTION
метод сделал protected, чтобы была возможность в дочернем классе его переопределить, добавив собственную логику